### PR TITLE
Set up CI

### DIFF
--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,0 +1,12 @@
+pipeline:
+  release:
+    image: plugins/npm
+    settings:
+      token:
+        from_secret: npm_access_token
+
+    # Pipeline level conditions aren't supported yet:
+    # https://github.com/woodpecker-ci/woodpecker/issues/283
+    when:
+      event: tag
+      tag: v*

--- a/.woodpecker/.test.yml
+++ b/.woodpecker/.test.yml
@@ -1,0 +1,12 @@
+pipeline:
+  test:
+    image: node:14
+    commands:
+      - npm ci
+      - npm run lint
+
+    # Pipeline level conditions aren't supported yet:
+    # https://github.com/woodpecker-ci/woodpecker/issues/283
+    when:
+      event:
+        - pull_request


### PR DESCRIPTION
This enables Woodpecker CI for this repo:
- pushed tags will be released to npm
- eslint will run when code is pushed to a pull request