### PR TITLE
Update to `uuid` v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4227,9 +4227,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "libphonenumber-js": "^1.9.6",
     "moment": "^2.24.0",
     "rdflib": "^2.2.19",
-    "uuid": "^7.0.3",
+    "uuid": "^8.3.2",
     "validator": "^13.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
No code changes are required since we were already using the new import syntax.