### PR TITLE
Use root level conditions

### DIFF
--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -3,21 +3,11 @@ pipeline:
     image: node:14
     commands:
       - npm ci
-
-    # Pipeline level conditions aren't supported yet:
-    # https://github.com/woodpecker-ci/woodpecker/issues/283
-    when:
-      event: tag
-      tag: v*
-
   release:
     image: plugins/npm
     settings:
       token:
         from_secret: npm_access_token
-
-    # Pipeline level conditions aren't supported yet:
-    # https://github.com/woodpecker-ci/woodpecker/issues/283
-    when:
-      event: tag
-      tag: v*
+when:
+  event: tag
+  tag: v*

--- a/.woodpecker/.test.yml
+++ b/.woodpecker/.test.yml
@@ -1,14 +1,20 @@
 pipeline:
-  test:
+  install:
     image: node:14
     commands:
       - npm ci
+  lint:
+    image: node:14
+    commands:
       - npm run lint
+  build:
+    image: node:14
+    commands:
       - npm run build
+  test:
+    image: node:14
+    commands:
       - npm test
-
-    # Pipeline level conditions aren't supported yet:
-    # https://github.com/woodpecker-ci/woodpecker/issues/283
-    when:
-      event:
-        - pull_request
+when:
+  event:
+    - pull_request


### PR DESCRIPTION
This ensures the pipeline is only visible if its conditions are met and allows us to split commands into multiple steps without having to repeat those conditions.