### PR TITLE
Add array support to the `exact value` constraint

### DIFF
--- a/src/constraints/exact-value.js
+++ b/src/constraints/exact-value.js
@@ -7,5 +7,10 @@ import { FORM } from "../namespaces.js";
 export default function constraintExactValue(value, options) {
   const { constraintUri, store } = options;
   const expected = store.any(constraintUri, FORM("customValue"), undefined);
-  return value.value == expected.value;
+
+  if (Array.isArray(value)) {
+    return value.length === 1 && value[0].value === expected.value;
+  } else {
+    return value.value == expected.value;
+  }
 }


### PR DESCRIPTION
Some form fields always return an array but we still want to check if the selected value matches the predefined one. An array is considered valid if it contains only a single literal, and the literal value is the same as the defined `customValue`.

There is some overlap with the SingleCodelistValue, but that can only be used for codelists and it expects the data to be part of the store which is not always the case.
