### PR TITLE
List forking-store as a peerDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4223,6 +4223,15 @@
       "dev": true,
       "optional": true
     },
+    "forking-store": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/forking-store/-/forking-store-2.0.0.tgz",
+      "integrity": "sha512-pW0/aWYYLXjLt4AqNYEoa4HxtAEKc2ljIA3zBMeJy6ia8ZLdG/oQ8aS0mwtWAK6jyLT/c2EsOM3ta2RsLzseYA==",
+      "dev": true,
+      "requires": {
+        "rdflib": "^2.2.19"
+      }
+    },
     "form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "uuid": "^9.0.0",
     "validator": "^13.5.2"
   },
+  "peerDependencies": {
+    "forking-store": "^2.0.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
@@ -50,6 +53,7 @@
     "eslint": "^8.18.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-n": "^15.2.3",
+    "forking-store": "^2.0.0",
     "prettier": "^2.8.4",
     "release-it": "^15.4.1"
   },


### PR DESCRIPTION
We already assumed this was the case implicitly. All helpers that receive a store option assume a forking-store instance. This change makes it more explicit.

This might be breaking if consumers didn't list forking-store as a dependency yet, but we consider this an oversight of the previous implementation so not breaking.