### PR TITLE
Also validate sub forms in `validateForms`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,5 +8,6 @@
 .woodpecker/
 
 // Test files
+tests/*
 **/*.test.js
 

--- a/src/fields-for-form.js
+++ b/src/fields-for-form.js
@@ -11,6 +11,10 @@ export function fieldsForForm(form, options) {
   return fields;
 }
 
+export function fieldsForSubForm(form, options) {
+  return fieldsForFormModelV2(form, options);
+}
+
 export function getFormModelVersion(form, { store, formGraph }) {
   if (isFormModelV2(form, { store, formGraph })) {
     return "v2";

--- a/src/get-scope.js
+++ b/src/get-scope.js
@@ -1,0 +1,7 @@
+import { FORM } from "./namespaces.js";
+
+export function getScope(field, options) {
+  const { store, formGraph } = options;
+  const scope = store.any(field, FORM("scope"), undefined, formGraph);
+  return scope;
+}

--- a/src/import-triples-for-form.js
+++ b/src/import-triples-for-form.js
@@ -1,5 +1,6 @@
-import { FORM, SHACL } from "./namespaces.js";
+import { SHACL } from "./namespaces.js";
 import { fieldsForForm } from "./fields-for-form.js";
+import { getScope } from "./get-scope.js";
 import { triplesForPath, triplesForScope } from "./triples-for.js";
 
 export default function importTriplesForForm(
@@ -41,9 +42,3 @@ export default function importTriplesForForm(
   return datasetTriples;
 }
 export { importTriplesForForm };
-
-function getScope(field, options) {
-  const { store, formGraph } = options;
-  const scope = store.any(field, FORM("scope"), undefined, formGraph);
-  return scope;
-}

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,11 +1,55 @@
+import { NamedNode } from "rdflib";
 import { FORM, RDF } from "./namespaces.js";
-import { fieldsForForm } from "./fields-for-form.js";
+import { fieldsForForm, fieldsForSubForm } from "./fields-for-form.js";
 import { check, checkTriples } from "./constraints.js";
+import { getScope } from "./get-scope.js";
+import { triplesForScope } from "./triples-for.js";
 
 export function validateForm(form, options) {
-  const fields = fieldsForForm(form, options);
-  const fieldValidations = fields.map((field) => validateField(field, options));
-  return fieldValidations.reduce((acc, value) => acc && value, true);
+  const topLevelFields = fieldsForForm(form, options);
+
+  return validateFields(topLevelFields, options);
+}
+
+function validateFields(fields, options) {
+  const fieldValidations = fields.map((field) => {
+    if (isListing(field, options)) {
+      const listing = field;
+      const scope = getScope(listing, options);
+      const { values: subFormSourceNodes } = triplesForScope(scope, options);
+      const hasSubFormData = subFormSourceNodes.length > 0;
+
+      if (hasSubFormData) {
+        const { store } = options;
+        const subForm = store.any(listing, FORM("each"), undefined);
+        const subformFields = fieldsForSubForm(subForm, options);
+
+        return subFormSourceNodes
+          .map((sourceNode) => {
+            return validateFields(subformFields, { ...options, sourceNode });
+          })
+          .every(Boolean);
+      } else {
+        // TODO: should we validate sh:minCount / sh:maxCount?
+        return true;
+      }
+    } else {
+      return validateField(field, options);
+    }
+  });
+  return fieldValidations.every(Boolean);
+}
+
+function isListing(field, options) {
+  let { store, formGraph } = options;
+  return Boolean(
+    store.any(
+      field,
+      RDF("type"),
+      new NamedNode("http://lblod.data.gift/vocabularies/forms/Listing"),
+      formGraph
+    )
+  );
 }
 
 export function validateField(fieldUri, options) {

--- a/tests/fixtures/validate-form/form.ttl
+++ b/tests/fixtures/validate-form/form.ttl
@@ -1,0 +1,131 @@
+# Copied from an ember-submission-form-fields example:
+# https://github.com/lblod/ember-submission-form-fields/blob/91c2dc73d2ccb114432efbbfdc18eeb0fc72b9af/tests/dummy/public/test-forms/tables/form.ttl
+
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix schema: <http://schema.org/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+
+##########################################################
+# form
+##########################################################
+ext:form a form:Form, form:TopLevelForm ;
+    form:includes ext:administrativeUnitsL.
+
+##########################################################
+#  property-group
+##########################################################
+ext:mainPg a form:PropertyGroup;
+    sh:name "Bewerk betrokken lokale besturen" ;
+    sh:order 1 .
+
+##########################################################
+#  listing-scope: administrativeUnit
+##########################################################
+ext:administrativeUnitListingS a form:Scope;
+  sh:path ext:administrativeUnit.
+
+##########################################################
+#  Listing: Administrative unit
+##########################################################
+ext:administrativeUnitsL a form:Listing;
+  # a form:ListingTable;
+  form:each ext:administrativeUnitFormItem;
+  form:scope ext:administrativeUnitListingS;
+  form:createGenerator ext:administrativeUnitGenerator;
+  form:canAdd true;
+  form:addLabel "Voeg nieuw betrokken lokaal bestuur toe";
+  form:canRemove true;
+  sh:minCount 3;
+  sh:maxCount 10;
+  form:removeLabel "Verwijder";
+  form:tableIndexLabel "#";
+  form:showTableRowIndex true;
+  sh:group ext:mainPg;
+  sh:order 2 .
+
+##########################################################
+#  Subform: administrativeUnit
+##########################################################
+ext:administrativeUnitFormItem a form:SubForm;
+   # sh:name "Betrokken lokale besturen" ;
+   form:includes ext:administrativeUnitNameF;
+   form:includes ext:administrativeUnitTypeOfInvolvementF;
+   form:includes ext:administrativeUnitInvolvementPercentageF;
+   form:includes ext:administrativeUnitDescriptionF;
+   form:hasFieldGroup ext:mainPg.
+
+##########################################################
+# Field: administrativeUnit name
+##########################################################
+ext:administrativeUnitNameF a form:Field ;
+    sh:name "Naam" ;
+    sh:order 1 ;
+    sh:path ext:name ;
+    form:options """{"conceptScheme":"http://example.concept/concept-schemes/administrative-units","searchEnabled":false}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht."@nl;
+        sh:path ext:name] ;
+    sh:group ext:mainPg .
+
+##########################################################
+# Field: type of involvement
+##########################################################
+ext:administrativeUnitTypeOfInvolvementF a form:Field ;
+    sh:name "Type betrokkenheid" ;
+    sh:order 2 ;
+    sh:path ext:typeOfInvolvement ;
+    form:options """{"conceptScheme":"http://example.concept/concept-schemes/type-of-involvement","searchEnabled":false}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht."@nl;
+        sh:path ext:typeOfInvolvement] ;
+    sh:group ext:mainPg .
+
+##########################################################
+# Field: involvement percentage
+##########################################################
+ext:administrativeUnitInvolvementPercentageF a form:Field ;
+    sh:name "Financieel percentage" ;
+    form:help "Het totaal van alle percentages moet gelijk zijn aan 100";
+    sh:order 3;
+    sh:path ext:involvementPercentage;
+    form:options """{}""" ;
+    form:displayType displayTypes:numericalInput ;
+    form:validations
+      [ a form:PositiveNumber ;
+        form:grouping form:MatchEvery ;
+        sh:resultMessage "Het percentage moet groter zijn dan 0."@nl;
+        sh:path ext:involvementPercentage] ;
+    sh:group ext:mainPg .
+
+##########################################################
+# Field: description
+##########################################################
+ext:administrativeUnitDescriptionF a form:Field ;
+    sh:name "Beschrijving" ;
+    sh:order 4;
+    sh:path ext:description;
+    form:displayType displayTypes:textArea ;
+    sh:group ext:mainPg .
+
+##########################################################
+#  Generator: administrativeUnit
+##########################################################
+ext:administrativeUnitGenerator a form:Generator;
+  form:prototype [
+    form:shape [
+      a ext:AdministrativeUnit ;
+      ext:involvementPercentage 0
+    ]
+  ];
+  form:dataGenerator form:addMuUuid.

--- a/tests/fixtures/validate-form/source-with-valid-listing-field-data.ttl
+++ b/tests/fixtures/validate-form/source-with-valid-listing-field-data.ttl
@@ -1,0 +1,15 @@
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+
+<http://ember-submission-form-fields/source-node> a ext:form;
+  ext:administrativeUnit <http://administrative-unit/1>;
+  ext:administrativeUnit <http://administrative-unit/2>.
+
+<http://administrative-unit/1> a ext:AdministrativeUnit;
+  ext:name <http://example.concept/concepts/brugge>;
+  ext:typeOfInvolvement <http://example.concept/concepts/mede-financierend>;
+  ext:involvementPercentage 2.
+
+<http://administrative-unit/2> a ext:AdministrativeUnit;
+  ext:name <http://example.concept/concepts/antwerpen>;
+  ext:typeOfInvolvement <http://example.concept/concepts/toezichthoudend>;
+  ext:involvementPercentage 0.

--- a/tests/fixtures/validate-form/source-without-listing-field-data.ttl
+++ b/tests/fixtures/validate-form/source-without-listing-field-data.ttl
@@ -1,0 +1,8 @@
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+
+<http://ember-submission-form-fields/source-node> a ext:form;
+  ext:administrativeUnit <http://administrative-unit/1>;
+  ext:administrativeUnit <http://administrative-unit/2>.
+
+<http://administrative-unit/1> a ext:AdministrativeUnit.
+<http://administrative-unit/2> a ext:AdministrativeUnit.

--- a/tests/validate-form.test.js
+++ b/tests/validate-form.test.js
@@ -1,0 +1,75 @@
+import test from "ava";
+import { NamedNode } from "rdflib";
+import ForkingStore from "forking-store";
+import { readFileSync } from "node:fs";
+import { RDF, FORM, validateForm } from "../src/index.js";
+
+const FORM_GRAPHS = {
+  formGraph: new NamedNode("http://data.lblod.info/form"),
+  metaGraph: new NamedNode("http://data.lblod.info/metagraph"),
+  sourceGraph: new NamedNode(`http://data.lblod.info/sourcegraph`),
+};
+
+const SOURCE_NODE = new NamedNode(
+  "http://ember-submission-form-fields/source-node"
+);
+
+function readFixtureFile(filePath) {
+  return readFileSync(
+    new URL(`fixtures/${filePath}`, import.meta.url),
+    "utf-8"
+  );
+}
+
+test("it validates all the form fields including the ones in sub forms", (t) => {
+  const formTtl = readFixtureFile("validate-form/form.ttl");
+
+  let store = new ForkingStore();
+  store.parse(formTtl, FORM_GRAPHS.formGraph, "text/turtle");
+
+  const form = store.any(
+    undefined,
+    RDF("type"),
+    FORM("Form"),
+    FORM_GRAPHS.formGraph
+  );
+
+  let isValid = validateForm(form, {
+    store,
+    form,
+    sourceNode: SOURCE_NODE,
+    ...FORM_GRAPHS,
+  });
+
+  t.true(
+    isValid,
+    "The source data doesn't contain listing items, so the sub form fields aren't validated yet"
+  );
+
+  let sourceTtl = readFixtureFile(
+    "validate-form/source-without-listing-field-data.ttl"
+  );
+  store.parse(sourceTtl, FORM_GRAPHS.sourceGraph, "text/turtle");
+  isValid = validateForm(form, {
+    store,
+    form,
+    sourceNode: SOURCE_NODE,
+    ...FORM_GRAPHS,
+  });
+  t.false(
+    isValid,
+    "The source data contains listing item root nodes, but no data for the fields so the validations fail"
+  );
+
+  sourceTtl = readFixtureFile(
+    "validate-form/source-with-valid-listing-field-data.ttl"
+  );
+  store.parse(sourceTtl, FORM_GRAPHS.sourceGraph, "text/turtle");
+  isValid = validateForm(form, {
+    store,
+    form,
+    sourceNode: SOURCE_NODE,
+    ...FORM_GRAPHS,
+  });
+  t.true(isValid, "The source data contains valid listing item data");
+});


### PR DESCRIPTION
This adds logic to the `validateForms` helper so that it also supports sub forms (listings).

The current implementation considers a subform valid if all the fields in the sub form are valid, or if there is no data for the sub form. This might change in the future if we want to validate `sh:minCount` and `sh:maxCount`.

Supersedes #32 

The easiest way to test this in an Ember app would be to link the code into the https://github.com/lblod/ember-submission-form-fields addon and run the example forms.
To test this in frontend loket I would use `yalc` (or a manual "file" dependency) since then you can use npm overrides to force that version.