### PR TITLE
Refactor the `valid-uri` constraint

### DIFF
--- a/.babelrc.cjs
+++ b/.babelrc.cjs
@@ -11,9 +11,7 @@ module.exports = function (api) {
         },
       ],
     ],
-    plugins: [
-      ["module-extension", { js: "cjs" }], // The built files need to use the .cjs extension to import other relative files
-    ],
+    plugins: ["./babel/cjs-extension"],
     ignore: ["**/*.test.js"],
   };
 };

--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,9 @@
 .release-it.json
 .woodpecker/
 
+// Custom babel plugins
+/babel/
+
 // Test files
 tests/*
 **/*.test.js

--- a/babel/cjs-extension.js
+++ b/babel/cjs-extension.js
@@ -1,0 +1,39 @@
+/**
+ * A simple babel plugin that replaces .js with .cjs for all relative imports.
+ * We publish both ESM and CJS modules, but the CJS version requires .cjs extensions to work properly.
+ */
+export default function cjsExtensionPlugin() {
+  return {
+    visitor: {
+      ImportDeclaration: maybeChangeExtension,
+      ExportNamedDeclaration: maybeChangeExtension,
+      ExportAllDeclaration: maybeChangeExtension,
+    },
+  };
+}
+
+function maybeChangeExtension(path) {
+  if (hasImportSource(path)) {
+    const source = path.node.source;
+
+    if (isRelativeImport(source)) {
+      toCjsExtension(source);
+    }
+  }
+}
+
+/**
+ * Checks if the node has a source. Only re-exports have a source which we need to change.
+ * @returns {boolean}
+ */
+function hasImportSource(path) {
+  return Boolean(path.node.source);
+}
+
+function isRelativeImport(source) {
+  return source.value.startsWith(".");
+}
+
+function toCjsExtension(source) {
+  source.value = source.value.replace(".js", ".cjs");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@babel/node": "^7.22.19",
         "@babel/preset-env": "^7.22.20",
         "ava": "^4.3.3",
-        "babel-plugin-module-extension": "^0.1.3",
         "eslint": "^8.18.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-n": "^15.2.3",
@@ -3084,12 +3083,6 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
-    },
-    "node_modules/babel-plugin-module-extension": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-extension/-/babel-plugin-module-extension-0.1.3.tgz",
-      "integrity": "sha512-/qinVu5EfAFlmmgAZMpg0apcHW52g0tgU8c9LONlbM1pKCYrlYLMltKmKBEIr7If4K2eQUNOtdBzIHkP28jBcw==",
-      "dev": true
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@babel/node": "^7.22.19",
     "@babel/preset-env": "^7.22.20",
     "ava": "^4.3.3",
-    "babel-plugin-module-extension": "^0.1.3",
     "eslint": "^8.18.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-n": "^15.2.3",

--- a/src/constraints/valid-uri.js
+++ b/src/constraints/valid-uri.js
@@ -1,9 +1,10 @@
-import validator from "validator";
+import isURL from "validator/lib/isURL.js";
+
 /**
  * Checks if it is a valid uri
  */
 export default function constraintValidUri(value /*, options*/) {
-  return validator.isURL(value.value, {
+  return isURL(value.value, {
     require_protocol: true,
     require_valid_protocol: true,
   });


### PR DESCRIPTION
The `validator` package has a large impact on bundle size since it contains a lot of features. To reduce the bundle size we can import the needed validators directly.

This reduces the bundle size by about 94kb minified / 28kb gzipped:
![image](https://github.com/lblod/submission-form-helpers/assets/3533236/c39076ad-d556-4fef-89da-d8ab22cb557a)
