### PR TITLE
Feature/form data node type

### DIFF
--- a/src/add-simple-form-value.js
+++ b/src/add-simple-form-value.js
@@ -1,6 +1,6 @@
 import { Statement } from "rdflib";
 import { FORM, RDF } from "./namespaces.js";
-import { triplesForPath } from "./triples-for.js";
+import { triplesForPath } from "./triples-for/triples-for-path.js";
 
 export function addSimpleFormValue(value, options) {
   const { store } = options;

--- a/src/add-simple-form-value.js
+++ b/src/add-simple-form-value.js
@@ -1,4 +1,6 @@
-import { triplesForPath } from "./triples-for/triples-for-path.js";
+import { Statement } from "rdflib";
+import { FORM, RDF } from "./namespaces.js";
+import { triplesForPath } from "./triples-for.js";
 
 export function addSimpleFormValue(value, options) {
   const { store } = options;
@@ -19,6 +21,24 @@ export function addSimpleFormValue(value, options) {
     const newTriple = dataset.triples.slice(-1)[0];
     newTriple.object = value;
     triplesToAdd.push(newTriple);
+  }
+
+  // Add missing FormDataNode types for subjects without (rdf:type form:FormDataNode)
+  const triplesToAddLength = triplesToAdd.length
+
+  for (let index = 0; index < triplesToAddLength; index++) {
+    const triple = triplesToAdd[index]
+
+    if (triple.subject?.value?.startsWith('http://data.lblod.info/form-data/nodes/')) {
+      triplesToAdd.push(
+        new Statement(
+          triple.subject,
+          RDF("type"),
+          FORM("FormDataNode"),
+          triple.graph
+        )
+      )
+    }
   }
 
   store.addAll(triplesToAdd);

--- a/src/remove-simple-form-value.js
+++ b/src/remove-simple-form-value.js
@@ -1,6 +1,6 @@
 import { Statement } from "rdflib";
 import { FORM, RDF } from "./namespaces.js";
-import { triplesForPath } from "./triples-for.js";
+import { triplesForPath } from "./triples-for/triples-for-path.js";
 
 export function removeSimpleFormValue(value, options) {
   const { store } = options;


### PR DESCRIPTION
## ID
DGS-105

 ## Description
Currently no (rdf:type form:FormDataNode) type is being attached to the <http://data.lblod.info/form-data/nodes/123> subjects that are generated by this library. For example here: https://github.com/lblod/submission-form-helpers/blob/cb51b9b6f51dca40f27d5116ec704f078b8f6a56/src/triples-for/triples-for-unscoped-path.js#L105-L114

We need a type attached to this subject so that we can identify it and export it (in a different part of the app/loket)

more info: https://github.com/lblod/app-digitaal-loket/pull/456#issuecomment-1771215311

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

- Yalc this package to ember-submission-form-fields
- add minimal form with 2 input fields. 
Its important you add a "complex" sh:path to both. 
` sh:path ( schema:contactPoint foaf:firstName ) ;` & 
` sh:path ( schema:contactPoint foaf:lastName ) ;`
- also use the table from lang-string since you will need to see the generated triples see https://aatauil.github.io/ember-submission-form-fields/lang-strings

Expected behaviour:
- when typing a value in the input field and then un-focuing, I would expect the following triples:
```
<application-form> schema:contactPoint <http://data.lblod.info/form-data/nodes/123> 
<http://data.lblod.info/form-data/nodes/123> rdf:type form:FormDataNode
<http://data.lblod.info/form-data/nodes/123> foaf:firstName "my-input"
```

- when emptying the field you should see all fields removed. 

important: the `<http://data.lblod.info/form-data/nodes/123> rdf:type form:FormDataNode` should only be removed when there are no <http://data.lblod.info/form-data/nodes/123> instances with data attached to it!

In essense if there is a <http://data.lblod.info/form-data/nodes/123> with data attached to it, it should have a type attached to it