### PR TITLE
[DL-5623] Add a new `DateInPast` constraint

### DIFF
--- a/src/constraints.js
+++ b/src/constraints.js
@@ -24,6 +24,7 @@ import maxLength from "./constraints/max-length.js";
 import validEngagementTable from "./constraints/valid-engagement-table.js";
 import hasOneNumberGreaterThanInFields from "./constraints/has-one-number-greater-than-in-fields.js";
 import matchValues from "./constraints/match-values.js";
+import dateInPast from "./constraints/date-in-past.js";
 
 export default function constraintForUri(uri) {
   switch (String(uri)) {
@@ -73,6 +74,8 @@ export default function constraintForUri(uri) {
       return hasOneNumberGreaterThanInFields;
     case "http://lblod.data.gift/vocabularies/forms/MatchValues":
       return matchValues;
+    case "http://lblod.data.gift/vocabularies/forms/DateInPast":
+      return dateInPast;
     default:
       return false; //TODO: TBD
   }

--- a/src/constraints/date-in-past.js
+++ b/src/constraints/date-in-past.js
@@ -1,0 +1,19 @@
+import { Literal } from "rdflib";
+import { XSD } from "../namespaces.js";
+
+/**
+ * @param {Literal} dateLiteral
+ * @returns {boolean}
+ */
+export default function dateInPast(dateLiteral /*, options*/) {
+  if (
+    dateLiteral.datatype.equals(XSD("date")) ||
+    dateLiteral.datatype.equals(XSD("dateTime"))
+  ) {
+    const date = Literal.toJS(dateLiteral);
+
+    return date <= Date.now();
+  }
+
+  return false;
+}

--- a/tests/constraints/date-in-past.test.js
+++ b/tests/constraints/date-in-past.test.js
@@ -1,0 +1,42 @@
+import test from "ava";
+import { Literal } from "rdflib";
+import dateInPast from "../../src/constraints/date-in-past.js";
+
+test("it works for xsd:date literals", (t) => {
+  const pastDate = dateLiteral("2024-01-18");
+  t.true(dateInPast(pastDate));
+
+  const now = new Date();
+  const nextYear = now.getFullYear() + 1;
+  const futureDate = dateLiteral(`${nextYear}-01-18`);
+  t.false(dateInPast(futureDate));
+});
+
+test("it works for xsd:dateTime literals", (t) => {
+  let testDate = dateTimeLiteral("2024-01-19T11:38:43Z");
+  t.true(dateInPast(testDate));
+
+  const now = new Date();
+  const nextYear = now.getFullYear() + 1;
+
+  testDate = dateTimeLiteral(`${nextYear}-01-19T11:38:43Z`);
+  t.false(dateInPast(testDate));
+});
+
+test("it returns `false` if it's not a date literal", (t) => {
+  t.false(dateInPast(Literal.fromNumber(1)));
+  t.false(dateInPast(Literal.fromBoolean(false)));
+  t.false(dateInPast(Literal.fromValue("foo")));
+});
+
+function dateLiteral(dateString) {
+  return new Literal(dateString, null, "http://www.w3.org/2001/XMLSchema#date");
+}
+
+function dateTimeLiteral(dateTimeString) {
+  return new Literal(
+    dateTimeString,
+    null,
+    "http://www.w3.org/2001/XMLSchema#dateTime"
+  );
+}


### PR DESCRIPTION
The URI/name for the constraint is still up for debate

Options:
- `form:DateInPast` (current implementation, matches the other constraint naming the best)
- `form:IsDateInPast`, sounds like a boolean but the other constraints don't do that
- `form:DateInPastConstraint` more clear that it's a constraint, but not all constraints have this suffix.
- `IsNotInFuture` (mentioned by Felix, but I wasn't sure about the negative in the name)
- ? (something else)