### PR TITLE
[LPDC-1425] Fix an issue with the `addMuUuid` generator

### DIFF
--- a/src/generators.js
+++ b/src/generators.js
@@ -84,19 +84,23 @@ function addExtraUuids(dataset, { store, sourceGraph, sourceNode }) {
   ];
   const extraTriples = [];
   subjectValues.forEach((subjectV) => {
-    // this is because the dataset's source node can be renamed to the original source node of the form
-    const trueSubject =
-      subjectV === dataset.sourceNodes[0].value
-        ? sourceNode
-        : new NamedNode(subjectV);
-    const alreadyHasUuid = store.any(
-      trueSubject,
-      MU("uuid"),
-      undefined,
-      sourceGraph
-    );
-    if (alreadyHasUuid) {
-      return;
+    // sourceNode isn't always defined which leads to incorrect behavior and no added uuids as a result
+    // TODO: find out if this is the best way to fix it. I'm not sure if `sourceNode` is actually the correct thing to use here.
+    if (sourceNode) {
+      // this is because the dataset's source node can be renamed to the original source node of the form
+      const trueSubject =
+        subjectV === dataset.sourceNodes[0].value
+          ? sourceNode
+          : new NamedNode(subjectV);
+      const alreadyHasUuid = store.any(
+        trueSubject,
+        MU("uuid"),
+        undefined,
+        sourceGraph
+      );
+      if (alreadyHasUuid) {
+        return;
+      }
     }
     extraTriples.push(
       new Statement(new NamedNode(subjectV), MU("uuid"), uuidv4())


### PR DESCRIPTION
The code in https://github.com/lblod/submission-form-helpers/pull/54 assumed a `sourceNode` was always passed into the `addExtraUuids` util, which isn't the case for all our code flows.

We now always add a uuid if `sourceNode` is undefined, which is a quick workaround so we unblock our apps. We should look into this more thoroughly to see if that's the best solution (and add some tests) in the future.